### PR TITLE
 Hoping to make the extension beta-compatible

### DIFF
--- a/chrome/content/mailboxalert/about.xul
+++ b/chrome/content/mailboxalert/about.xul
@@ -8,7 +8,7 @@
 	orient="vertical"
 	autostretch="always"
 	onload="sizeToContent()"
-	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+	xmlns="https://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
 
 
@@ -22,14 +22,14 @@
 <groupbox align="center" orient="horizontal">
 <vbox>
   <text value="&mailboxalert.name;" style="font-weight: bold; font-size: x-large;"/>
-  <text value="&mailboxalert.version;: 0.18.0"/>
+  <text value="&mailboxalert.version;: 0.19.0"/>
   <separator class="thin"/>
   <text value="&mailboxalert.about.created;:" style="font-weight: bold;"/>
   <text value="&mailboxalert.author;" class="url"
         onclick="window.open('http://tjeb.nl'); window.close();"/>
   <separator class="thin"/>
     <text value="&mailboxalert.website;" style="font-weight: bold;"/>
-    <text value="http://tjeb.nl/Projects/Mailbox_Alert"
+    <text value="https://tjeb.nl/Projects/Mailbox_Alert"
           class="url"
         onclick="window.open('http://tjeb.nl'); window.close();"/>
   <separator class="thin"/>

--- a/chrome/content/mailboxalert/about.xul
+++ b/chrome/content/mailboxalert/about.xul
@@ -26,12 +26,12 @@
   <separator class="thin"/>
   <text value="&mailboxalert.about.created;:" style="font-weight: bold;"/>
   <text value="&mailboxalert.author;" class="url"
-        onclick="window.open('http://tjeb.nl'); window.close();"/>
+        onclick="window.open('https://tjeb.nl'); window.close();"/>
   <separator class="thin"/>
     <text value="&mailboxalert.website;" style="font-weight: bold;"/>
     <text value="https://tjeb.nl/Projects/Mailbox_Alert"
           class="url"
-        onclick="window.open('http://tjeb.nl'); window.close();"/>
+        onclick="window.open('https://tjeb.nl'); window.close();"/>
   <separator class="thin"/>
 </vbox>
 <spring flex="1"/>

--- a/install.rdf
+++ b/install.rdf
@@ -9,7 +9,7 @@ xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 			<Description>
 				<em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
 				<em:minVersion>3.0</em:minVersion>
-				<em:maxVersion>60.*</em:maxVersion>
+				<em:maxVersion>67.*</em:maxVersion>
 			</Description>
 		</em:targetApplication>
 
@@ -24,10 +24,10 @@ xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 		<em:id>{9c21158b-2c76-4d0a-980a-c51fc9cefaa7}</em:id>
 		<em:name>Mailbox Alert</em:name>
                 <em:type>2</em:type>
-		<em:version>0.18.0</em:version>
+		<em:version>0.19.0</em:version>
 		<em:description>Mailbox Alert - Extension for Thunderbird.</em:description>
 		<em:creator>Jelte Jansen</em:creator>
-		<em:homepageURL>http://tjeb.nl/Projects/Mailbox_Alert</em:homepageURL>
+		<em:homepageURL>https://tjeb.nl/Projects/Mailbox_Alert</em:homepageURL>
 		<em:iconURL>chrome://mailboxalert/skin/mailboxalert.png</em:iconURL>
 		<em:aboutURL>chrome://mailboxalert/content/about.xul</em:aboutURL>
 


### PR DESCRIPTION
Using Thunderbird v64 (for compatibility with uBlock Origin) seems to turn off Mailbox Alert, so I figured out that I could just as well bump up the version numbers for the betas and in expectation of the next stable version.

I've also upgraded a few HTTP links to HTTPS.