### PR TITLE
Make toast notification style works with Thunderbird dark themes

### DIFF
--- a/content/newmailalert.css
+++ b/content/newmailalert.css
@@ -62,6 +62,6 @@ window {
 #alertMessageField {
   margin: 0px 10px 0px 4px;
   padding: 0px 1px 0px 1px;
-  background-color: transparent;
+  background-color: -moz-field;
+  color: -moz-fieldtext;
 }
-

--- a/content/newmailalert.css
+++ b/content/newmailalert.css
@@ -45,23 +45,23 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 window {
-  border: solid #000000 1px;
-  /*background-color: transparent;*/
+  background-color: transparent;
 }
 
 
 #alertImage {
+  margin: 15px 0px 0px 15px;
   list-style-image: url("chrome://branding/content/icon64.png");
 }
 
 #subject {
+  margin: 10px 20px 0px 10px;
   font-weight: bold;
 }
 
 #alertMessageField {
-  margin: 0px 0px 0px 4px;
+  margin: 0px 10px 0px 4px;
   padding: 0px 1px 0px 1px;
-  background-color: white;
-  border: solid #000000 1px;
+  background-color: transparent;
 }
 


### PR DESCRIPTION
The toast notification appears with white forced background color, which is not nice to see when using dark themes with Thunderbird.
![Screenshot from 2021-01-21 16-28-27](https://user-images.githubusercontent.com/37073343/105373141-a3a52380-5c06-11eb-998c-bf673e79bf17.png)
This PR is intended to set the background color to `transparent` and add some padding around the notification rendered elements.
![Screenshot from 2021-01-21 16-29-01](https://user-images.githubusercontent.com/37073343/105373292-d2bb9500-5c06-11eb-89a1-d16734a4aa7f.png)
