### PR TITLE
Fix %msg_preview is always <empty>

### DIFF
--- a/content/mailboxalert_funcs.js
+++ b/content/mailboxalert_funcs.js
@@ -169,26 +169,40 @@ MailboxAlert.createAlertData = function (mailbox, last_unread) {
             // (we may have the parent by now)
             var url_listener = MailboxAlert.createUrlListener();
             var urlscalled = false;
-            // API changed from TB2 to TB3, first try TB3 API, if
-            // exception, try the other one
+            // API changed several times in the past, try from newest to oldest
             try {
                 urlscalled = this.last_unread.folder.fetchMsgPreviewText(
                                         [this.last_unread.messageKey],
-                                        1, false, url_listener);
-            } catch(e) {
+                                        url_listener);
+            } catch(e4) {
                 try {
-                    var aOutAsync = {};
-                    this.last_unread.folder.fetchMsgPreviewText(
-                              [this.last_unread.messageKey],
-                              1, false, url_listener, aOutAsync);
-                    if (aOutAsync && aOutAsync.value) {
-                        urlscalled = true;
+                    // Since TB v73
+                    urlscalled = this.last_unread.folder.fetchMsgPreviewText(
+                                            [this.last_unread.messageKey],
+                                            false, url_listener);
+                } catch(e3) {
+                    try {
+                        // Since TB v3
+                        urlscalled = this.last_unread.folder.fetchMsgPreviewText(
+                                                [this.last_unread.messageKey],
+                                                1, false, url_listener);
+                    } catch(e2) {
+                        try {
+                            var aOutAsync = {};
+                            // TB <= v2
+                            this.last_unread.folder.fetchMsgPreviewText(
+                                    [this.last_unread.messageKey],
+                                    1, false, url_listener, aOutAsync);
+                            if (aOutAsync && aOutAsync.value) {
+                                urlscalled = true;
+                            }
+                        } catch(e1) {
+                            // On some folders (news for instance), and in
+                            // some other cases, fetch just throws an exception
+                            // if so, just set an empty previewtext
+                            this.last_unread.setProperty("preview", [e4.message,e4.data,e4].map(fe=>JSON.stringify(fe)).join('|') + "<empty>" + [e3.message,e3.data,e3].map(fe=>JSON.stringify(fe)).join('|'));
+                        }
                     }
-                } catch(e2) {
-                    // On some folders (news for instance), and in
-                    // some other cases, fetch just throws an exception
-                    // if so, just set an empty previewtext
-                    this.last_unread.setProperty("preview", "<empty>");
                 }
             }
             if (urlscalled) {

--- a/content/mailboxalert_funcs.js
+++ b/content/mailboxalert_funcs.js
@@ -200,7 +200,7 @@ MailboxAlert.createAlertData = function (mailbox, last_unread) {
                             // On some folders (news for instance), and in
                             // some other cases, fetch just throws an exception
                             // if so, just set an empty previewtext
-                            this.last_unread.setProperty("preview", [e4.message,e4.data,e4].map(fe=>JSON.stringify(fe)).join('|') + "<empty>" + [e3.message,e3.data,e3].map(fe=>JSON.stringify(fe)).join('|'));
+                            this.last_unread.setProperty("preview", "<empty>");
                         }
                     }
                 }


### PR DESCRIPTION
SinceTB v73 https://bugzilla.mozilla.org/show_bug.cgi?id=1604645 (diff: https://hg.mozilla.org/comm-central/rev/262318f613ca#l2.20), the fetchMsgPreviewText signature had changed again, and you couldn't use `%msg_preview` in Mailbox-Alert, as it would always be `<empty>`.
With the next TB (bug still open) https://bugzilla.mozilla.org/show_bug.cgi?id=1733504 (diff: https://hg.mozilla.org/comm-central/rev/50c31d90adf5#l2.19), fetchMsgPreviewText will change *yet again*

This PR adds syntax compatibility for both the current and the upcoming version.